### PR TITLE
Fix do/retry recursion error for login retries

### DIFF
--- a/pkg/dsdk/connection.go
+++ b/pkg/dsdk/connection.go
@@ -259,7 +259,7 @@ func (c *ApiConnection) do(ctxt context.Context, method, url string, ro *greq.Re
 		ro.Headers["Auth-Token"] = c.apikey
 		return c.do(ctxt, method, url, ro, rs, false, sensitive)
 	}
-	if err == badStatus[Retry503] || err == badStatus[ConnectionError] {
+	if retry && (err == badStatus[Retry503] || err == badStatus[ConnectionError]) {
 		return c.retry(ctxt, method, url, ro, rs, sensitive)
 	}
 	if eresp != nil {
@@ -400,7 +400,7 @@ func (c *ApiConnection) Login(ctxt context.Context) (*ApiErrorResponse, error) {
 	if c.ldap != "" {
 		ro.Data["remote_server"] = c.ldap
 	}
-	apiresp, err := c.do(ctxt, "PUT", "login", ro, login, false, true)
+	apiresp, err := c.do(ctxt, "PUT", "login", ro, login, true, true)
 	c.apikey = login.Key
 	return apiresp, err
 }


### PR DESCRIPTION
The retry function attempts to call `do` repeatedly with a backoff until
a timeout and so `do` calls from retry should not attempt to retry
themselves or it will end up retrying recursively very rapidly

Only the change in `do` is necessary to fix the recursion, however
the change in `Login` allows logins to continue to attempt retries on
503s or connection errors