### PR TITLE
Allow users to supply a custom http.Client

### DIFF
--- a/pkg/dsdk/connection.go
+++ b/pkg/dsdk/connection.go
@@ -45,6 +45,7 @@ type ApiConnection struct {
 	ldap       string
 	apikey     string
 	baseUrl    *url.URL
+	httpClient *http.Client
 }
 
 type ApiErrorResponse struct {
@@ -204,6 +205,12 @@ func (c *ApiConnection) do(ctxt context.Context, method, url string, ro *greq.Re
 	if sensitive {
 		sdata = []byte("********")
 	}
+	if ro.HTTPClient == nil && c.httpClient != nil {
+		ro.HTTPClient = c.httpClient
+	}
+	if ro.Context == nil {
+		ro.Context = ctxt
+	}
 	if ro.Headers == nil {
 		ro.Headers = make(map[string]string, 1)
 	}
@@ -234,6 +241,7 @@ func (c *ApiConnection) do(ctxt context.Context, method, url string, ro *greq.Re
 	}
 
 	// The actual request happens here
+	// Context is passed through ro.Context
 	resp, err := greq.DoRegularRequest(method, gurl.String(), ro)
 
 	t2 := time.Now()
@@ -294,7 +302,11 @@ func (c *ApiConnection) doWithAuth(ctxt context.Context, method, url string, ro 
 }
 
 func NewApiConnection(c *udc.UDC, secure bool) *ApiConnection {
-	url, err := makeBaseUrl(c.MgmtIp, c.ApiVersion, secure)
+	return NewApiConnectionWithHTTPClient(c, secure, nil)
+}
+
+func NewApiConnectionWithHTTPClient(c *udc.UDC, secure bool, client *http.Client) *ApiConnection {
+	u, err := makeBaseUrl(c.MgmtIp, c.ApiVersion, secure)
 	if err != nil {
 		Log().Fatalf("%s", err)
 	}
@@ -305,7 +317,8 @@ func NewApiConnection(c *udc.UDC, secure bool) *ApiConnection {
 		tenant:     c.Tenant,
 		ldap:       c.Ldap,
 		secure:     secure,
-		baseUrl:    url,
+		baseUrl:    u,
+		httpClient: client,
 		m:          &sync.Mutex{},
 	}
 }

--- a/pkg/dsdk/sdk.go
+++ b/pkg/dsdk/sdk.go
@@ -3,6 +3,7 @@ package dsdk
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	udc "github.com/Datera/go-udc/pkg/udc"
 	uuid "github.com/google/uuid"
@@ -38,6 +39,10 @@ type SDK struct {
 }
 
 func NewSDK(c *udc.UDC, secure bool) (*SDK, error) {
+	return NewSDKWithHTTPClient(c, secure, nil)
+}
+
+func NewSDKWithHTTPClient(c *udc.UDC, secure bool, client *http.Client) (*SDK, error) {
 	var err error
 	if c == nil {
 		c, err = udc.GetConfig()
@@ -46,7 +51,7 @@ func NewSDK(c *udc.UDC, secure bool) (*SDK, error) {
 			return nil, err
 		}
 	}
-	conn := NewApiConnection(c, secure)
+	conn := NewApiConnectionWithHTTPClient(c, secure, client)
 	return &SDK{
 		conf:                 c,
 		Conn:                 conn,


### PR DESCRIPTION
Also propagates context (required for special functionality in some http.Client implementations)