### PR TITLE
Add RemoteProvider Operations request and function

### DIFF
--- a/pkg/dsdk/remote_provider.go
+++ b/pkg/dsdk/remote_provider.go
@@ -230,13 +230,13 @@ func (e *RemoteProvider) Reload(ro *RemoteProviderReloadRequest) (*RemoteProvide
 	return resp, nil, nil
 }
 
-type RemoteProviderOperationsUpdateRequest struct {
+type RemoteProviderOperationsSetRequest struct {
 	Ctxt        context.Context `json:"-"`
 	OperationId string          `json:"-"`
 	Action      string          `json:"action"` //available options are 'clear' and 'abort'
 }
 
-func (e *RemoteProvider) UpdateOperation(ao *RemoteProviderOperationsUpdateRequest) (*RemoteProvider, *ApiErrorResponse, error) {
+func (e *RemoteProvider) SetOperation(ao *RemoteProviderOperationsSetRequest) (*RemoteProvider, *ApiErrorResponse, error) {
 
 	gro := &greq.RequestOptions{JSON: ao}
 	rs, apierr, err := GetConn(ao.Ctxt).Put(ao.Ctxt, _path.Join(e.Path, "operations", ao.OperationId), gro)

--- a/pkg/dsdk/remote_provider.go
+++ b/pkg/dsdk/remote_provider.go
@@ -232,7 +232,7 @@ func (e *RemoteProvider) Reload(ro *RemoteProviderReloadRequest) (*RemoteProvide
 
 type RemoteProviderOperationsUpdateRequest struct {
 	Ctxt        context.Context `json:"-"`
-	OperationId string          `json:"omit"`
+	OperationId string          `json:"-"`
 	Action      string          `json:"action"` //available options are 'clear' and 'abort'
 }
 

--- a/pkg/dsdk/remote_provider.go
+++ b/pkg/dsdk/remote_provider.go
@@ -229,3 +229,26 @@ func (e *RemoteProvider) Reload(ro *RemoteProviderReloadRequest) (*RemoteProvide
 	RegisterRemoteProviderEndpoints(resp)
 	return resp, nil, nil
 }
+
+type RemoteProviderOperationsUpdateRequest struct {
+	Ctxt   context.Context `json:"-"`
+	Action string          `json:"action"` //available options are 'clear' and 'abort'
+}
+
+func (e *RemoteProvider) PerformOperation(ao *RemoteProviderOperationsUpdateRequest) (*RemoteProvider, *ApiErrorResponse, error) {
+
+	gro := &greq.RequestOptions{JSON: ao}
+	rs, apierr, err := GetConn(ao.Ctxt).Put(ao.Ctxt, e.Path, gro)
+	if apierr != nil {
+		return nil, apierr, err
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	resp := &RemoteProvider{}
+	if err = FillStruct(rs.Data, resp); err != nil {
+		return nil, nil, err
+	}
+	RegisterRemoteProviderEndpoints(resp)
+	return resp, nil, nil
+}

--- a/pkg/dsdk/remote_provider.go
+++ b/pkg/dsdk/remote_provider.go
@@ -236,7 +236,7 @@ type RemoteProviderOperationsUpdateRequest struct {
 	Action      string          `json:"action"` //available options are 'clear' and 'abort'
 }
 
-func (e *RemoteProvider) PerformOperation(ao *RemoteProviderOperationsUpdateRequest) (*RemoteProvider, *ApiErrorResponse, error) {
+func (e *RemoteProvider) CreateOperation(ao *RemoteProviderOperationsUpdateRequest) (*RemoteProvider, *ApiErrorResponse, error) {
 
 	gro := &greq.RequestOptions{JSON: ao}
 	rs, apierr, err := GetConn(ao.Ctxt).Put(ao.Ctxt, _path.Join(e.Path, "operations", ao.OperationId), gro)

--- a/pkg/dsdk/remote_provider.go
+++ b/pkg/dsdk/remote_provider.go
@@ -236,7 +236,7 @@ type RemoteProviderOperationsUpdateRequest struct {
 	Action      string          `json:"action"` //available options are 'clear' and 'abort'
 }
 
-func (e *RemoteProvider) CreateOperation(ao *RemoteProviderOperationsUpdateRequest) (*RemoteProvider, *ApiErrorResponse, error) {
+func (e *RemoteProvider) UpdateOperation(ao *RemoteProviderOperationsUpdateRequest) (*RemoteProvider, *ApiErrorResponse, error) {
 
 	gro := &greq.RequestOptions{JSON: ao}
 	rs, apierr, err := GetConn(ao.Ctxt).Put(ao.Ctxt, _path.Join(e.Path, "operations", ao.OperationId), gro)

--- a/pkg/dsdk/remote_provider.go
+++ b/pkg/dsdk/remote_provider.go
@@ -236,7 +236,22 @@ type RemoteProviderOperationsSetRequest struct {
 	Action      string          `json:"action"` //available options are 'clear' and 'abort'
 }
 
-func (e *RemoteProvider) SetOperation(ao *RemoteProviderOperationsSetRequest) (*RemoteProvider, *ApiErrorResponse, error) {
+type RemoteOperation struct {
+	Path               string `json:"path" mapstructure:"path"`
+	Uuid               string `json:"uuid" mapstructure:"uuid"`
+	RemoteProviderUuid string `json:"remote_provider_uuid" mapstructure:"remote_provider_uuid"`
+	AppInstanceUuid    string `json:"app_instance_uuid" mapstructure:"app_instance_uuid"`
+	OpState            string `json:"op_state" mapstructure:"op_state"`
+	OpType             string `json:"op_type" mapstructure:"op_type"`
+	PercentDone        int    `json:"percent_done" mapstructure:"percent_done"`
+	TotalTasksDone     int    `json:"total_tasks_done" mapstructure:"total_tasks_done"`
+	TotalTasksIssued   int    `json:"total_tasks_issued" mapstructure:"total_tasks_issued"`
+	References         struct {
+		SnapshotAppInstancePath string `json:"snapshot_app_instance_path" "mapstructure:"snapshot_app_instance_path"`
+	} `json:"references" mapstructure:"references"`
+}
+
+func (e *RemoteProvider) SetOperation(ao *RemoteProviderOperationsSetRequest) (*RemoteOperation, *ApiErrorResponse, error) {
 
 	gro := &greq.RequestOptions{JSON: ao}
 	rs, apierr, err := GetConn(ao.Ctxt).Put(ao.Ctxt, _path.Join(e.Path, "operations", ao.OperationId), gro)
@@ -246,10 +261,10 @@ func (e *RemoteProvider) SetOperation(ao *RemoteProviderOperationsSetRequest) (*
 	if err != nil {
 		return nil, nil, err
 	}
-	resp := &RemoteProvider{}
+	resp := &RemoteOperation{}
 	if err = FillStruct(rs.Data, resp); err != nil {
 		return nil, nil, err
 	}
-	RegisterRemoteProviderEndpoints(resp)
+
 	return resp, nil, nil
 }

--- a/pkg/dsdk/remote_provider.go
+++ b/pkg/dsdk/remote_provider.go
@@ -231,14 +231,15 @@ func (e *RemoteProvider) Reload(ro *RemoteProviderReloadRequest) (*RemoteProvide
 }
 
 type RemoteProviderOperationsUpdateRequest struct {
-	Ctxt   context.Context `json:"-"`
-	Action string          `json:"action"` //available options are 'clear' and 'abort'
+	Ctxt        context.Context `json:"-"`
+	OperationId string          `json:"omit"`
+	Action      string          `json:"action"` //available options are 'clear' and 'abort'
 }
 
 func (e *RemoteProvider) PerformOperation(ao *RemoteProviderOperationsUpdateRequest) (*RemoteProvider, *ApiErrorResponse, error) {
 
 	gro := &greq.RequestOptions{JSON: ao}
-	rs, apierr, err := GetConn(ao.Ctxt).Put(ao.Ctxt, e.Path, gro)
+	rs, apierr, err := GetConn(ao.Ctxt).Put(ao.Ctxt, _path.Join(e.Path, "operations", ao.OperationId), gro)
 	if apierr != nil {
 		return nil, apierr, err
 	}


### PR DESCRIPTION
Remote Providers can have two operations performed through the Datera Rest API: abort, and clear

This provides the mechanism to execute those operations