### PR TITLE
Fix several additional retry issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/Datera/go-sdk v1.1.14
 	github.com/Datera/go-udc v1.1.0
+	github.com/google/go-cmp v0.4.0
 	github.com/google/uuid v1.1.0
 	github.com/levigross/grequests v0.0.0-20181123014746-f3f67e7783bb
 	github.com/mitchellh/mapstructure v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Datera/go-udc v1.1.0 h1:00PLH1rWv9Ygde4JCWzpg1I5Ka1RVMMN10bTXXOS58o=
 github.com/Datera/go-udc v1.1.0/go.mod h1:Z1tRCsem0RwlAJ6W0nnBda74SngfTQAE88xAU8mOpJ8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/uuid v1.1.0 h1:Jf4mxPC/ziBnoPIdpQdPJ9OeiomAUHLvxmPRSPH9m4s=
@@ -33,5 +35,7 @@ golang.org/x/net v0.0.0-20190108155000-395948e2f546 h1:tkMg6+6TF2qZ/3I8fw+DiNgPS
 golang.org/x/net v0.0.0-20190108155000-395948e2f546/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 h1:I6FyU15t786LL7oL/hn43zqTuEGr4PN7F4XJ1p4E3Y8=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/h2non/gock.v1 v1.0.15 h1:SzLqcIlb/fDfg7UvukMpNcWsu7sI5tWwL+KCATZqks0=
 gopkg.in/h2non/gock.v1 v1.0.15/go.mod h1:sX4zAkdYX1TRGJ2JY156cFspQn4yRWn6p9EMdODlynE=

--- a/pkg/dsdk/connection.go
+++ b/pkg/dsdk/connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -21,6 +22,7 @@ import (
 
 var (
 	RetryTimeout           = int64(300)
+	ErrRetryTimeout        = errors.New("timeout reached before request completed successfully during retries")
 	InvalidRequest         = 400
 	PermissionDenied       = 401
 	Retry503               = 503
@@ -38,7 +40,7 @@ var (
 )
 
 type ApiConnection struct {
-	m          *sync.Mutex
+	m          *sync.RWMutex
 	username   string
 	password   string
 	apiVersion string
@@ -223,7 +225,7 @@ func makeBaseUrl(h, apiv string, secure bool) (*url.URL, error) {
 	return url.Parse(fmt.Sprintf("http://%s:7717/v%s", h, apiv))
 }
 
-func checkResponse(resp *greq.Response, err error, retry bool) (*ApiErrorResponse, error) {
+func translateErrors(resp *greq.Response, err error) (*ApiErrorResponse, error) {
 	if err != nil {
 		Log().Error(err)
 		if strings.Contains(err.Error(), "connect: connection refused") {
@@ -231,17 +233,30 @@ func checkResponse(resp *greq.Response, err error, retry bool) (*ApiErrorRespons
 		}
 		return nil, err
 	}
-	if resp.StatusCode == PermissionDenied && retry {
-		return nil, badStatus[RetryRequestAfterLogin]
-	} else if resp.StatusCode == Retry503 && retry {
-		return nil, badStatus[Retry503]
-	}
+
 	if !resp.Ok {
 		eresp := &ApiErrorResponse{}
-		resp.JSON(eresp)
+		err := resp.JSON(eresp)
+		if err != nil {
+			eresp.Message = fmt.Sprintf("failed to unmarshal ApiErrorResponse: %v", err)
+		}
+
+		// in some cases (like 503s) the response JSON doesn't contain
+		// all the fields of the ApiErrorResponse and we want to always
+		// be able to rely on at least having the status code
+		if eresp.Http == 0 {
+			eresp.Http = resp.StatusCode
+		}
 		return eresp, badStatus[resp.StatusCode]
 	}
 	return nil, nil
+}
+
+// hasLoggedIn reports whether the ApiConnection has successfully authenticated once
+func (c *ApiConnection) hasLoggedIn() bool {
+	c.m.RLock()
+	defer c.m.RUnlock()
+	return c.apikey != ""
 }
 
 func (c *ApiConnection) retry(ctxt context.Context, method, url string, ro *greq.RequestOptions, rs interface{}, sensitive bool) (*ApiErrorResponse, error) {
@@ -264,7 +279,7 @@ func (c *ApiConnection) retry(ctxt context.Context, method, url string, ro *greq
 		time.Sleep(time.Second * time.Duration(backoff*backoff))
 		backoff += 1
 	}
-	return apiresp, fmt.Errorf("Timeout reached before request completed successfully during retries")
+	return apiresp, ErrRetryTimeout
 }
 
 func (c *ApiConnection) do(ctxt context.Context, method, url string, ro *greq.RequestOptions, rs interface{}, retry, sensitive bool) (*ApiErrorResponse, error) {
@@ -330,15 +345,22 @@ func (c *ApiConnection) do(ctxt context.Context, method, url string, ro *greq.Re
 		"response_timedelta": tDelta.Seconds(),
 		"request_url":        gurl.String(),
 		"response_payload":   rdata,
+		"response_code":      resp.StatusCode,
 	}).Debugf("Datera SDK response received")
-	eresp, err := checkResponse(resp, err, retry)
-	if err == badStatus[RetryRequestAfterLogin] {
+
+	eresp, err := translateErrors(resp, err)
+	// if we have logged in successfully we may just need to refresh the apikey
+	if c.hasLoggedIn() && err == badStatus[PermissionDenied] {
+		// if this login fails then the credentials may no longer be valid and we shouldn't
+		// retry the login again
 		if apiresp, err2 := c.Login(ctxt); err2 != nil {
 			Log().Errorf("%s", err)
 			Log().Errorf("%s", err2)
 			return apiresp, err2
 		}
+		c.m.RLock()
 		ro.Headers["Auth-Token"] = c.apikey
+		c.m.RUnlock()
 		return c.do(ctxt, method, url, ro, rs, false, sensitive)
 	}
 	if retry && (err == badStatus[Retry503] || err == badStatus[ConnectionError]) {
@@ -365,13 +387,15 @@ func (c *ApiConnection) doWithAuth(ctxt context.Context, method, url string, ro 
 	if ro == nil {
 		ro = &greq.RequestOptions{}
 	}
-	if c.apikey == "" {
-		if apierr, err := c.Login(ctxt); err != nil {
+	if !c.hasLoggedIn() {
+		if apierr, err := c.Login(ctxt); apierr != nil || err != nil {
 			Log().Errorf("Login failure: %s, %s", Pretty(apierr), err)
 			return apierr, err
 		}
 	}
+	c.m.RLock()
 	ro.Headers = map[string]string{"tenant": c.tenant, "Auth-Token": c.apikey}
+	c.m.RUnlock()
 	return c.do(ctxt, method, url, ro, rs, true, false)
 }
 
@@ -393,7 +417,7 @@ func NewApiConnectionWithHTTPClient(c *udc.UDC, secure bool, client *http.Client
 		secure:     secure,
 		baseUrl:    u,
 		httpClient: client,
-		m:          &sync.Mutex{},
+		m:          &sync.RWMutex{},
 	}
 }
 
@@ -470,8 +494,6 @@ func (c *ApiConnection) ApiVersions() []string {
 }
 
 func (c *ApiConnection) Login(ctxt context.Context) (*ApiErrorResponse, error) {
-	c.m.Lock()
-	defer c.m.Unlock()
 	login := &ApiLogin{}
 	ro := &greq.RequestOptions{
 		Data: map[string]string{
@@ -483,6 +505,19 @@ func (c *ApiConnection) Login(ctxt context.Context) (*ApiErrorResponse, error) {
 		ro.Data["remote_server"] = c.ldap
 	}
 	apiresp, err := c.do(ctxt, "PUT", "login", ro, login, true, true)
-	c.apikey = login.Key
+	c.m.Lock()
+	if (apiresp != nil && apiresp.Http == PermissionDenied) || (err != nil && err == badStatus[PermissionDenied]) {
+		c.apikey = ""
+	} else {
+		c.apikey = login.Key
+	}
+
+	c.m.Unlock()
 	return apiresp, err
+}
+
+func (c *ApiConnection) Logout() {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.apikey = ""
 }

--- a/pkg/dsdk/connection.go
+++ b/pkg/dsdk/connection.go
@@ -354,7 +354,6 @@ func (c *ApiConnection) do(ctxt context.Context, method, url string, ro *greq.Re
 		// if we have logged in successfully before we may just need to refresh the apikey
 		// and retry the original request
 		if c.hasLoggedIn() {
-			// if this login fails then the
 			c.Logout()
 			if apiresp, err2 := c.Login(ctxt); apiresp != nil || err2 != nil {
 				Log().Errorf("%s", err)

--- a/tests/sdk_test.go
+++ b/tests/sdk_test.go
@@ -1,11 +1,17 @@
 package dsdk_test
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/Datera/go-udc/pkg/udc"
-	dsdk "github.com/tjcelaya/go-datera/pkg/dsdk"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tjcelaya/go-datera/pkg/dsdk"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -47,25 +53,368 @@ func TestSDKInitiatorCreate(t *testing.T) {
 	}
 }
 
-// TestRetry ensures that a request that gets a 503 will retry and if the
-// next response is a 200 will return the result
-func TestRetry(t *testing.T) {
-	defer gock.Off()
+func TestRetryScenarios(t *testing.T) {
+	originalTO := dsdk.RetryTimeout
+	dsdk.RetryTimeout = int64(5) // lower the retry timeout so any test failures that result in a retry loop don't take 5 minutes
+	defer func() { dsdk.RetryTimeout = originalTO }()
+	testApiResponse := dsdk.ApiOuter{Data: map[string]interface{}{"name": "the system"}}
+	testSystem := &dsdk.System{}
+	if err := dsdk.FillStruct(testApiResponse.Data, testSystem); err != nil {
+		t.Fatal(err)
+	}
 
+	apiErr401 := &dsdk.ApiErrorResponse{Name: "AuthFailedError", Http: 401}
+
+	type expected struct {
+		ApiErr *dsdk.ApiErrorResponse
+		Err    error
+		Data   *dsdk.System
+	}
+	testCases := []struct {
+		desc     string
+		setup    func()
+		expected expected
+	}{
+		{
+			desc: "returns success when a 503 is followed by a 200",
+			setup: func() {
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				// mock a 503 followed by success
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(503).
+					// On 503 errors the api may not return all fields of the ApiErrorResponse
+					JSON(&dsdk.ApiErrorResponse{Message: "overloaded"})
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(200).
+					JSON(testApiResponse)
+			},
+			expected: expected{
+				Data: testSystem,
+			},
+		},
+		{
+			desc: "returns success when multiple 503s are followed by a 200",
+			setup: func() {
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				// mock 2 503s followed by success
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(503).
+					// On 503 errors the api may not return all fields of the ApiErrorResponse
+					JSON(&dsdk.ApiErrorResponse{Message: "overloaded"})
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(503).
+					// On 503 errors the api may not return all fields of the ApiErrorResponse
+					JSON(&dsdk.ApiErrorResponse{Message: "overloaded"})
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(200).
+					JSON(testApiResponse)
+			},
+			expected: expected{
+				Data: testSystem,
+			},
+		},
+		{
+			desc: "returns success on connection error followed by 200",
+			setup: func() {
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				// mock 2 503s followed by success
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					ReplyError(errors.New("connect: connection refused"))
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(200).
+					JSON(testApiResponse)
+			},
+			expected: expected{
+				Data: testSystem,
+			},
+		},
+		{
+			desc: "returns success on connection error followed by 200 during login",
+			setup: func() {
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					ReplyError(errors.New("connect: connection refused"))
+
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				// mock 2 503s followed by success
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					ReplyError(errors.New("connect: connection refused"))
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(200).
+					JSON(testApiResponse)
+			},
+			expected: expected{
+				Data: testSystem,
+			},
+		},
+		{
+			desc: "returns success on a 401 followed by successful re-authentication",
+			setup: func() {
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				// mock 401 followed by relogin and success
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(dsdk.PermissionDenied).
+					JSON(&dsdk.ApiErrorResponse{Name: "AuthFailedError", Http: 401})
+
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(200).
+					JSON(testApiResponse)
+			},
+			expected: expected{
+				Data: testSystem,
+			},
+		},
+		{
+			desc: "returns success on a 503 -> 401 -> 200",
+			setup: func() {
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				// mock 503 followed by 401 then relogin and success
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(503).
+					// On 503 errors the api may not return all fields of the ApiErrorResponse
+					JSON(&dsdk.ApiErrorResponse{Message: "overloaded"})
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(dsdk.PermissionDenied).
+					JSON(apiErr401)
+
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(200).
+					JSON(testApiResponse)
+			},
+			expected: expected{
+				Data: testSystem,
+			},
+		},
+		{
+			desc: "returns success on a 503 -> 401 -> 503 -> 200",
+			setup: func() {
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				// mock 503 followed by 401 then relogin and success
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(503).
+					// On 503 errors the api may not return all fields of the ApiErrorResponse
+					JSON(&dsdk.ApiErrorResponse{Message: "overloaded"})
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(dsdk.PermissionDenied).
+					JSON(apiErr401)
+
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(503).
+					JSON(&dsdk.ApiErrorResponse{Message: "overloaded"})
+
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(200).
+					JSON(testApiResponse)
+			},
+			expected: expected{
+				Data: testSystem,
+			},
+		},
+		{
+			desc: "retries stop after a time limit",
+			setup: func() {
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				// mock multiple 503s followed by 200
+				for i := 0; i < 3; i++ {
+					gock.New("http://127.0.0.1:7717").
+						Get("/v1/system").
+						Reply(503).
+						// On 503 errors the api may not return all fields of the ApiErrorResponse
+						JSON(&dsdk.ApiErrorResponse{Message: "overloaded"})
+				}
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(200).
+					JSON(testApiResponse)
+			},
+			expected: expected{
+				Err: dsdk.ErrRetryTimeout,
+			},
+		},
+		{
+			desc: "does not retry on an initial login auth error",
+			setup: func() {
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(dsdk.PermissionDenied).
+					JSON(apiErr401)
+			},
+			expected: expected{
+				ApiErr: apiErr401,
+			},
+		},
+		{
+			desc: "does not retry on a 400",
+			setup: func() {
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(400).
+					JSON(&dsdk.ApiErrorResponse{Message: "invalid", Http: 400})
+			},
+			expected: expected{
+				ApiErr: &dsdk.ApiErrorResponse{Message: "invalid", Http: 400},
+			},
+		},
+		{
+			desc: "does not retry on a 400 encountered during a retry",
+			setup: func() {
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(503).
+					// On 503 errors the api may not return all fields of the ApiErrorResponse
+					JSON(&dsdk.ApiErrorResponse{Message: "overloaded"})
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(400).
+					JSON(&dsdk.ApiErrorResponse{Message: "invalid", Http: 400})
+			},
+			expected: expected{
+				ApiErr: &dsdk.ApiErrorResponse{Message: "invalid", Http: 400},
+			},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			defer gock.OffAll()
+			tC.setup()
+
+			sdk, err := dsdk.NewSDK(&udc.UDC{
+				MgmtIp:     "127.0.0.1",
+				Username:   "foo",
+				Password:   "bar",
+				ApiVersion: "1",
+			}, false)
+			if err != nil {
+				t.Error(err)
+			}
+			ctxt := sdk.NewContext()
+			s, aer, err := sdk.System.Get(&dsdk.SystemGetRequest{
+				Ctxt: ctxt,
+			})
+
+			if gock.HasUnmatchedRequest() {
+				for _, un := range gock.GetUnmatchedRequests() {
+					t.Errorf("unmatched request: %+v", un)
+				}
+				t.Fatal("received unexpected requests")
+			}
+
+			actual := expected{
+				ApiErr: aer,
+				Err:    err,
+				Data:   s,
+			}
+
+			if diff := cmp.Diff(tC.expected, actual, cmpopts.EquateErrors()); diff != "" {
+				t.Fatalf("did not get expected result: %s", diff)
+			}
+		})
+	}
+}
+
+func TestConcurrentUsage(t *testing.T) {
+	originalTO := dsdk.RetryTimeout
+	dsdk.RetryTimeout = int64(5) // lower the retry timeout so any test failures that result in a retry loop don't take 5 minutes
+	defer func() { dsdk.RetryTimeout = originalTO }()
 	gock.New("http://127.0.0.1:7717").
 		Put("/v1/login").
+		Persist().
 		Reply(200).
 		JSON(&dsdk.ApiLogin{Key: "thekey"})
-
-	// mock a 503 followed by success
 	gock.New("http://127.0.0.1:7717").
 		Get("/v1/system").
-		Reply(503)
-
-	gock.New("http://127.0.0.1:7717").
-		Get("/v1/system").
+		Persist().
 		Reply(200).
 		JSON(dsdk.ApiOuter{Data: map[string]interface{}{"name": "the system"}})
+
+	// work around https://github.com/levigross/grequests/issues/78
+	http.DefaultClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return nil
+	}
 
 	sdk, err := dsdk.NewSDK(&udc.UDC{
 		MgmtIp:     "127.0.0.1",
@@ -76,23 +425,46 @@ func TestRetry(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
 	ctxt := sdk.NewContext()
-	s, aer, err := sdk.System.Get(&dsdk.SystemGetRequest{
-		Ctxt: ctxt,
-	})
-
-	if gock.HasUnmatchedRequest() {
-		for _, un := range gock.GetUnmatchedRequests() {
-			t.Errorf("unmatched request: %+v", un)
+	doneCh := make(chan struct{})
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		for {
+			select {
+			case <-doneCh:
+				wg.Done()
+				return
+			default:
+			}
+			_, _, _ = sdk.System.Get(&dsdk.SystemGetRequest{
+				Ctxt: ctxt,
+			})
+			dsdk.GetConn(ctxt).Logout()
+			time.Sleep(20 * time.Millisecond)
 		}
-		t.Fatal("received unexpected requests")
-	}
+	}()
 
-	if aer != nil || err != nil {
-		t.Fatalf("errors should have been nil: %v %v", aer, err)
-	}
+	go func() {
+		for {
+			select {
+			case <-doneCh:
+				wg.Done()
+				return
+			default:
+			}
+			_, _, _ = sdk.System.Get(&dsdk.SystemGetRequest{
+				Ctxt: ctxt,
+			})
+			dsdk.GetConn(ctxt).Logout()
+			time.Sleep(19 * time.Millisecond)
+		}
+	}()
 
-	if s.Name != "the system" {
-		t.Fatalf("did not get expected result: %+v", s)
-	}
+	time.Sleep(3 * time.Second)
+	close(doneCh)
+	wg.Wait()
+
+	gock.OffAll()
 }

--- a/tests/sdk_test.go
+++ b/tests/sdk_test.go
@@ -317,6 +317,29 @@ func TestRetryScenarios(t *testing.T) {
 			},
 		},
 		{
+			desc: "does not retry after a 401 during a re-login",
+			setup: func() {
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(dsdk.PermissionDenied).
+					JSON(apiErr401)
+
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Persist().
+					Reply(dsdk.PermissionDenied).
+					JSON(apiErr401)
+			},
+			expected: expected{
+				ApiErr: apiErr401,
+			},
+		},
+		{
 			desc: "does not retry on a 400",
 			setup: func() {
 				gock.New("http://127.0.0.1:7717").


### PR DESCRIPTION
* Retry no longer stops after the second 503 error
* Retry no longer halts if a re-authentication is necessary during retry
* Fixes possible data race on access of ApiConnection.apikey
* Fixes deadlock on reentrant Login calls