### PR TITLE
Avoid replacing any original ApiErrorResponse message on an unmarshal…

### DIFF
--- a/pkg/dsdk/connection.go
+++ b/pkg/dsdk/connection.go
@@ -238,7 +238,7 @@ func translateErrors(resp *greq.Response, err error) (*ApiErrorResponse, error) 
 		eresp := &ApiErrorResponse{}
 		err := resp.JSON(eresp)
 		if err != nil {
-			eresp.Message = fmt.Sprintf("failed to unmarshal ApiErrorResponse: %v", err)
+			Log().Error(fmt.Sprintf("failed to unmarshal ApiErrorResponse %+v: %v", eresp, err))
 		}
 
 		// in some cases (like 503s) the response JSON doesn't contain


### PR DESCRIPTION
… error.

Happened to notice that now that we started checking the ApiErrorResponse unmarshal error it is actually happening in some cases:

```
2020-03-13T16:09:20-05:00 ERROR Recieved API Error {
	"name": "NotFoundError",
	"code": 16,
	"http": 404,
	"message": "failed to unmarshal ApiErrorResponse: json: cannot unmarshal number into Go struct field ApiErrorResponse.api_req_id of type string",
	"ts": "1584133760451"
```



