### PR TITLE
Disallow concurrent logins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,10 @@ require (
 	github.com/levigross/grequests v0.0.0-20190908174114-253788527a1a
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.3.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9 // indirect
 	gopkg.in/h2non/gock.v1 v1.0.15
+	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/mitchellh/mapstructure v1.3.1 h1:cCBH2gTD2K0OtLlv/Y5H01VQCqmlDxz30kS5
 github.com/mitchellh/mapstructure v1.3.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -48,3 +50,5 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IV
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/h2non/gock.v1 v1.0.15 h1:SzLqcIlb/fDfg7UvukMpNcWsu7sI5tWwL+KCATZqks0=
 gopkg.in/h2non/gock.v1 v1.0.15/go.mod h1:sX4zAkdYX1TRGJ2JY156cFspQn4yRWn6p9EMdODlynE=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/tests/sdk_test.go
+++ b/tests/sdk_test.go
@@ -1,6 +1,7 @@
 package dsdk_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -15,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 	dsdk "github.com/tjcelaya/go-datera/pkg/dsdk"
 	"gopkg.in/h2non/gock.v1"
+	"gotest.tools/assert"
 )
 
 func init() {
@@ -285,6 +287,50 @@ func TestRetryScenarios(t *testing.T) {
 			},
 		},
 		{
+			desc: "returns success on a 503 -> 401 -> (503 -> 200 on login) -> 503 -> 200",
+			setup: func() {
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				// mock 503 followed by 401 then relogin and success
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(503).
+					// On 503 errors the api may not return all fields of the ApiErrorResponse
+					JSON(&dsdk.ApiErrorResponse{Message: "overloaded"})
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(dsdk.PermissionDenied).
+					JSON(apiErr401)
+
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(503).
+					JSON(&dsdk.ApiErrorResponse{Message: "overloaded"})
+
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(503).
+					JSON(&dsdk.ApiErrorResponse{Message: "overloaded"})
+
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(200).
+					JSON(testApiResponse)
+			},
+			expected: expected{
+				Data: testSystem,
+			},
+		},
+		{
 			desc: "retries stop after a time limit",
 			setup: func() {
 				gock.New("http://127.0.0.1:7717").
@@ -383,6 +429,31 @@ func TestRetryScenarios(t *testing.T) {
 			},
 			expected: expected{
 				ApiErr: &dsdk.ApiErrorResponse{Message: "invalid", Http: 400},
+			},
+		},
+		{
+			desc: "401 during a relogin does not continue to retry login",
+			setup: func() {
+				// initial login succeeds
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(200).
+					JSON(&dsdk.ApiLogin{Key: "thekey"})
+
+				// get a 401 to force a re-login
+				gock.New("http://127.0.0.1:7717").
+					Get("/v1/system").
+					Reply(dsdk.PermissionDenied).
+					JSON(apiErr401)
+
+				// re-login gets a 401
+				gock.New("http://127.0.0.1:7717").
+					Put("/v1/login").
+					Reply(dsdk.PermissionDenied).
+					JSON(apiErr401)
+			},
+			expected: expected{
+				ApiErr: apiErr401,
 			},
 		},
 	}
@@ -496,4 +567,50 @@ func TestConcurrentUsage(t *testing.T) {
 	wg.Wait()
 
 	gock.OffAll()
+}
+
+// validates that concurrent login attempts will only actually log in once
+func TestConcurrentLoginAttempts(t *testing.T) {
+	defer gock.OffAll()
+
+	// set up mocks so that only a single login attempt will succeed and the rest will fail
+	gock.New("http://127.0.0.1:7717").
+		Put("/v1/login").
+		Reply(200).
+		JSON(&dsdk.ApiLogin{Key: "thekey"})
+	gock.New("http://127.0.0.1:7717").
+		Get("/v1/login").
+		Persist().
+		Reply(500).
+		JSON(&dsdk.ApiErrorResponse{Message: "goofed"})
+
+	conn := dsdk.NewApiConnection(&udc.UDC{
+		MgmtIp:     "127.0.0.1",
+		Username:   "foo",
+		Password:   "bar",
+		ApiVersion: "1",
+	}, false)
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	var aer1 *dsdk.ApiErrorResponse
+	var err1 error
+	var aer2 *dsdk.ApiErrorResponse
+	var err2 error
+	go func() {
+		aer1, err1 = conn.Login(context.Background())
+		wg.Done()
+	}()
+
+	go func() {
+		aer2, err2 = conn.Login(context.Background())
+		wg.Done()
+	}()
+
+	// if neither login attempt returned an error we can know that the login route was only called once
+	assert.NilError(t, err1)
+	assert.NilError(t, err2)
+	assert.Assert(t, aer1 == nil)
+	assert.Assert(t, aer2 == nil)
+
 }

--- a/tests/sdk_test.go
+++ b/tests/sdk_test.go
@@ -579,7 +579,7 @@ func TestConcurrentLoginAttempts(t *testing.T) {
 		Reply(200).
 		JSON(&dsdk.ApiLogin{Key: "thekey"})
 	gock.New("http://127.0.0.1:7717").
-		Get("/v1/login").
+		Put("/v1/login").
 		Persist().
 		Reply(500).
 		JSON(&dsdk.ApiErrorResponse{Message: "goofed"})
@@ -606,6 +606,8 @@ func TestConcurrentLoginAttempts(t *testing.T) {
 		aer2, err2 = conn.Login(context.Background())
 		wg.Done()
 	}()
+
+	wg.Wait()
 
 	// if neither login attempt returned an error we can know that the login route was only called once
 	assert.NilError(t, err1)


### PR DESCRIPTION
* Hold the mutex for the entire Login function
* Avoid deadlocks from attempting to take the lock from a function
  called during Login by adding a flag to signal when there is a Login
  active

This addresses an issue introduced by https://github.com/Datera/go-sdk/pull/10/commits/e6ba24e7505d32304e98f128b03ecdb9a25f513e#diff-ef40b515fe10f46d6039cce834cfe529R403
where moving the lock to after the PUT /login would allow concurrent
unnecessary login calls.  It also ensures that once a Login call
acquires the lock it will exit without calling /login if a previous
login has succeded